### PR TITLE
Rename class RedmineConfigStore so it can be found in dogu config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+### Fixed
+- Configuration in Cloudogu Ecosystem ([#31](https://github.com/scm-manager/scm-redmine-plugin/pull/31))
+
 ## 3.0.1 - 2021-06-04
 ### Fixed
 - Allow duplicate mapping entries ([#29](https://github.com/scm-manager/scm-redmine-plugin/pull/29))

--- a/src/main/java/sonia/scm/redmine/config/ConfigurationResolver.java
+++ b/src/main/java/sonia/scm/redmine/config/ConfigurationResolver.java
@@ -35,10 +35,10 @@ public final class ConfigurationResolver {
 
   private static final Logger LOG = LoggerFactory.getLogger(ConfigurationResolver.class);
 
-  private final RedmineConfigurationStore configurationStore;
+  private final RedmineConfigStore configurationStore;
 
   @Inject
-  public ConfigurationResolver(RedmineConfigurationStore configurationStore) {
+  public ConfigurationResolver(RedmineConfigStore configurationStore) {
     this.configurationStore = configurationStore;
   }
 

--- a/src/main/java/sonia/scm/redmine/config/RedmineConfigStore.java
+++ b/src/main/java/sonia/scm/redmine/config/RedmineConfigStore.java
@@ -30,14 +30,14 @@ import sonia.scm.store.ConfigurationStore;
 import sonia.scm.store.ConfigurationStoreFactory;
 
 @Singleton
-public class RedmineConfigurationStore {
+public class RedmineConfigStore {
 
   public static final String NAME = "redmine";
 
   private final ConfigurationStoreFactory storeFactory;
 
   @Inject
-  public RedmineConfigurationStore(ConfigurationStoreFactory storeFactory) {
+  public RedmineConfigStore(ConfigurationStoreFactory storeFactory) {
     this.storeFactory = storeFactory;
   }
 

--- a/src/main/java/sonia/scm/redmine/config/RedmineConfigurationResource.java
+++ b/src/main/java/sonia/scm/redmine/config/RedmineConfigurationResource.java
@@ -60,12 +60,12 @@ import static sonia.scm.NotFoundException.notFound;
 @Path("v2/redmine/configuration")
 public class RedmineConfigurationResource {
 
-  private RedmineConfigurationStore configStore;
+  private RedmineConfigStore configStore;
   private RedmineConfigurationMapper mapper;
   private RepositoryManager repositoryManager;
 
   @Inject
-  public RedmineConfigurationResource(RedmineConfigurationStore configStore, RedmineConfigurationMapper mapper, RepositoryManager repositoryManager) {
+  public RedmineConfigurationResource(RedmineConfigStore configStore, RedmineConfigurationMapper mapper, RepositoryManager repositoryManager) {
     this.configStore = configStore;
     this.mapper = mapper;
     this.repositoryManager = repositoryManager;
@@ -91,10 +91,9 @@ public class RedmineConfigurationResource {
       schema = @Schema(implementation = ErrorDto.class)
     )
   )
-  public Response updateGlobalConfiguration(RedmineGlobalConfigurationDto updatedConfig) {
+  public void updateGlobalConfiguration(RedmineGlobalConfigurationDto updatedConfig) {
     ConfigurationPermissions.write(Constants.NAME).check();
     configStore.storeConfiguration(mapper.map(updatedConfig, configStore.getConfiguration()));
-    return Response.ok().build();
   }
 
   @GET
@@ -149,11 +148,10 @@ public class RedmineConfigurationResource {
       schema = @Schema(implementation = ErrorDto.class)
     )
   )
-  public Response updateConfiguration(@PathParam("namespace") String namespace, @PathParam("name") String name, RedmineConfigurationDto updatedConfig) {
+  public void updateConfiguration(@PathParam("namespace") String namespace, @PathParam("name") String name, RedmineConfigurationDto updatedConfig) {
     Repository repository = loadRepository(namespace, name);
     RepositoryPermissions.custom(Constants.NAME, repository).check();
     configStore.storeConfiguration(mapper.map(updatedConfig, configStore.getConfiguration(repository)), repository);
-    return Response.ok().build();
   }
 
   @GET

--- a/src/main/java/sonia/scm/redmine/config/RedmineRepositoryConfigurationHalEnricher.java
+++ b/src/main/java/sonia/scm/redmine/config/RedmineRepositoryConfigurationHalEnricher.java
@@ -42,11 +42,11 @@ import javax.inject.Provider;
 public class RedmineRepositoryConfigurationHalEnricher implements HalEnricher {
 
   private final Provider<ScmPathInfoStore> scmPathInfoStoreProvider;
-  private final RedmineConfigurationStore redmineConfigurationStore;
+  private final RedmineConfigStore redmineConfigurationStore;
 
   @Inject
   public RedmineRepositoryConfigurationHalEnricher(Provider<ScmPathInfoStore> scmPathInfoStoreProvider,
-                                                   RedmineConfigurationStore redmineConfigurationStore) {
+                                                   RedmineConfigStore redmineConfigurationStore) {
     this.scmPathInfoStoreProvider = scmPathInfoStoreProvider;
     this.redmineConfigurationStore = redmineConfigurationStore;
   }

--- a/src/main/java/sonia/scm/redmine/update/RedmineV2ConfigMigrationUpdateStep.java
+++ b/src/main/java/sonia/scm/redmine/update/RedmineV2ConfigMigrationUpdateStep.java
@@ -27,7 +27,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import sonia.scm.migration.UpdateStep;
 import sonia.scm.plugin.Extension;
-import sonia.scm.redmine.config.RedmineConfigurationStore;
+import sonia.scm.redmine.config.RedmineConfigStore;
 import sonia.scm.redmine.config.RedmineConfiguration;
 import sonia.scm.redmine.config.TextFormatting;
 import sonia.scm.update.V1Properties;
@@ -47,10 +47,10 @@ public class RedmineV2ConfigMigrationUpdateStep implements UpdateStep {
   private static final Logger LOG = LoggerFactory.getLogger(RedmineV2ConfigMigrationUpdateStep.class);
 
   private final V1PropertyDAO v1PropertyDAO;
-  private final RedmineConfigurationStore configStore;
+  private final RedmineConfigStore configStore;
 
   @Inject
-  public RedmineV2ConfigMigrationUpdateStep(V1PropertyDAO v1PropertyDAO, RedmineConfigurationStore configStore) {
+  public RedmineV2ConfigMigrationUpdateStep(V1PropertyDAO v1PropertyDAO, RedmineConfigStore configStore) {
     this.v1PropertyDAO = v1PropertyDAO;
     this.configStore = configStore;
   }

--- a/src/test/java/sonia/scm/redmine/RedmineIssueTrackerProviderTest.java
+++ b/src/test/java/sonia/scm/redmine/RedmineIssueTrackerProviderTest.java
@@ -32,7 +32,7 @@ import sonia.scm.issuetracker.api.IssueTracker;
 import sonia.scm.issuetracker.spi.IssueTrackerBuilder;
 import sonia.scm.net.ahc.AdvancedHttpClient;
 import sonia.scm.redmine.config.ConfigurationResolver;
-import sonia.scm.redmine.config.RedmineConfigurationStore;
+import sonia.scm.redmine.config.RedmineConfigStore;
 import sonia.scm.redmine.config.RedmineGlobalConfiguration;
 import sonia.scm.repository.Repository;
 import sonia.scm.repository.RepositoryTestData;
@@ -51,7 +51,7 @@ class RedmineIssueTrackerProviderTest {
   @Mock
   private IssueTrackerBuilder builder;
 
-  private RedmineConfigurationStore configStore;
+  private RedmineConfigStore configStore;
 
   @Mock
   private Provider<AdvancedHttpClient> httpClientProvider;
@@ -65,7 +65,7 @@ class RedmineIssueTrackerProviderTest {
 
   @BeforeEach
   void setUpConfiguration() {
-    configStore = new RedmineConfigurationStore(new InMemoryConfigurationStoreFactory());
+    configStore = new RedmineConfigStore(new InMemoryConfigurationStoreFactory());
     issueTrackerProvider = new RedmineIssueTrackerProvider(
       new ConfigurationResolver(configStore),
       httpClientProvider

--- a/src/test/java/sonia/scm/redmine/config/ConfigurationResolverTest.java
+++ b/src/test/java/sonia/scm/redmine/config/ConfigurationResolverTest.java
@@ -36,7 +36,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class ConfigurationResolverTest {
 
-  private RedmineConfigurationStore store;
+  private RedmineConfigStore store;
 
   private ConfigurationResolver resolver;
 
@@ -44,7 +44,7 @@ class ConfigurationResolverTest {
 
   @BeforeEach
   void setUpResolver() {
-    store = new RedmineConfigurationStore(new InMemoryConfigurationStoreFactory());
+    store = new RedmineConfigStore(new InMemoryConfigurationStoreFactory());
     resolver = new ConfigurationResolver(store);
   }
 

--- a/src/test/java/sonia/scm/redmine/update/RedmineV2ConfigMigrationUpdateStepTest.java
+++ b/src/test/java/sonia/scm/redmine/update/RedmineV2ConfigMigrationUpdateStepTest.java
@@ -31,7 +31,7 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
-import sonia.scm.redmine.config.RedmineConfigurationStore;
+import sonia.scm.redmine.config.RedmineConfigStore;
 import sonia.scm.redmine.config.RedmineConfiguration;
 import sonia.scm.redmine.config.TextFormatting;
 import sonia.scm.update.V1PropertyDaoTestUtil;
@@ -52,7 +52,7 @@ class RedmineV2ConfigMigrationUpdateStepTest {
   V1PropertyDaoTestUtil testUtil = new V1PropertyDaoTestUtil();
 
   @Mock
-  RedmineConfigurationStore configStore;
+  RedmineConfigStore configStore;
   @Captor
   ArgumentCaptor<RedmineConfiguration> configurationCaptor;
   @Captor


### PR DESCRIPTION
## Proposed changes

The Cloudogu Ecosystem tries to configure the redmine plugin when it is installed. This is done by a Groovy script. This script relies on the class `RedmineConfigStore`, which has been renamed to `RedmineConfigurationStore` with the latest releases. Therefore the configuration script fails.

This change reverts this renaming.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Target branch is not master (in most cases develop should bet the target of choice) 
- [x] Code does not conflict with target branch
- [ ] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog` or CHANGELOG.md is updated for plugins

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
