### PR TITLE
Replace passwords/tokens with "dummy" only if they are not empty

### DIFF
--- a/gradle/changelog/empty_passwords.yaml
+++ b/gradle/changelog/empty_passwords.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Replace passwords/tokens with "dummy" only if they are not empty ([#49](https://github.com/scm-manager/scm-redmine-plugin/pull/49))

--- a/src/main/java/sonia/scm/redmine/config/RedmineConfigurationMapper.java
+++ b/src/main/java/sonia/scm/redmine/config/RedmineConfigurationMapper.java
@@ -26,6 +26,7 @@ package sonia.scm.redmine.config;
 import com.google.common.annotations.VisibleForTesting;
 import de.otto.edison.hal.Link;
 import de.otto.edison.hal.Links;
+import org.apache.commons.lang.StringUtils;
 import org.mapstruct.AfterMapping;
 import org.mapstruct.Context;
 import org.mapstruct.Mapper;
@@ -75,7 +76,9 @@ public abstract class RedmineConfigurationMapper extends HalAppenderMapper {
 
   @AfterMapping
   public void replacePasswordWithDummy(@MappingTarget RedmineConfigurationDto target) {
-    target.setPassword(DUMMY_PASSWORD);
+    if (StringUtils.isNotEmpty(target.getPassword())) {
+      target.setPassword(DUMMY_PASSWORD);
+    }
   }
 
   @AfterMapping

--- a/src/test/java/sonia/scm/redmine/config/RedmineConfigurationMapperTest.java
+++ b/src/test/java/sonia/scm/redmine/config/RedmineConfigurationMapperTest.java
@@ -156,6 +156,19 @@ public class RedmineConfigurationMapperTest {
     password = "secret",
     configuration = "classpath:sonia/scm/redmine/shiro.ini"
   )
+  public void shouldNotReplacePasswordAfterMappingDtoIfEmpty() {
+    RedmineConfiguration redmineConfiguration = createConfiguration();
+    redmineConfiguration.setPassword("");
+    RedmineConfigurationDto configuration = mapper.map(redmineConfiguration, createRepository());
+    assertEquals("", configuration.getPassword());
+  }
+
+  @Test
+  @SubjectAware(
+    username = "trillian",
+    password = "secret",
+    configuration = "classpath:sonia/scm/redmine/shiro.ini"
+  )
   public void shouldRestorePasswordAfterMappingFromGlobalDto() {
     RedmineGlobalConfigurationDto dto = createGlobalConfigurationDto();
     dto.setPassword(RedmineConfigurationMapper.DUMMY_PASSWORD);


### PR DESCRIPTION
## Proposed changes

Password, tokens and secrets should not be replaced with the "dummy" password if they are empty and sent to the client so that the UI shows the existence of a password properly.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [x] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
