### PR TITLE
Fix 'committer' and 'pushed by' labels

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,7 +23,7 @@
  */
 
 plugins {
-  id 'org.scm-manager.smp' version '0.12.0'
+  id 'org.scm-manager.smp' version '0.13.0'
 }
 
 dependencies {

--- a/gradle/changelog/fix_pusher_committer.yaml
+++ b/gradle/changelog/fix_pusher_committer.yaml
@@ -1,0 +1,2 @@
+- type: fixed
+  description: Committer and pushed by labels ([#58](https://github.com/scm-manager/scm-redmine-plugin/pull/58))

--- a/src/main/resources/scm/template/html/changeset_reference.mustache
+++ b/src/main/resources/scm/template/html/changeset_reference.mustache
@@ -2,6 +2,9 @@
   [SCM] Issue referenced by commit of repository {{ repository.namespace }}/{{ repository.name }}<br/><br/>
   {{ content.description }}<br/><br/>
   <strong>Author:</strong> {{ author }}<br/>
-  <strong>Committer:</strong> {{ principal }}<br/>
+  {{#contributors.Committed-by}}
+    <strong>Committed by:</strong> {{ . }}<br/>
+  {{/contributors.Committed-by}}
+  <strong>Pushed by:</strong> {{ principal }}<br/>
   <a href="{{ link }}" target="_blank" rel="noreferrer">Changes</a>
 </p>

--- a/src/main/resources/scm/template/html/changeset_statechange.mustache
+++ b/src/main/resources/scm/template/html/changeset_statechange.mustache
@@ -2,6 +2,9 @@
   [SCM] State change triggered by commit of repository {{ repository.namespace }}/{{ repository.name }}<br/><br/>
   {{ content.description }}<br/><br/>
   <strong>Author:</strong> {{ author }}<br/>
-  <strong>Committer:</strong> {{ principal }}<br/>
+  {{#contributors.Committed-by}}
+    <strong>Committed by:</strong> {{ . }}<br/>
+  {{/contributors.Committed-by}}
+  <strong>Pushed by:</strong> {{ principal }}<br/>
   <a href="{{ link }}" rel="noreferrer" target="_blank">Changes</a>
 </p>

--- a/src/main/resources/scm/template/markdown/changeset_reference.mustache
+++ b/src/main/resources/scm/template/markdown/changeset_reference.mustache
@@ -3,8 +3,11 @@
 {{ content.description }}
 
 **Author:** {{ author }}
+{{#contributors.Committed-by}}
+**Committed by:** {{ . }}
+{{/contributors.Committed-by}}
 {{#principal}}
-**Committer:** {{ principal }}
+**Pushed by:** {{ principal }}
 {{/principal}}
 
 [Changes]({{ link }})

--- a/src/main/resources/scm/template/markdown/changeset_statechange.mustache
+++ b/src/main/resources/scm/template/markdown/changeset_statechange.mustache
@@ -3,8 +3,11 @@
 {{ content.description }}
 
 **Author:** {{ author }}
+{{#contributors.Committed-by}}
+**Committed by:** {{ . }}
+{{/contributors.Committed-by}}
 {{#principal}}
-**Committer:** {{ principal }}
+**Pushed by:** {{ principal }}
 {{/principal}}
 
 [Changes]({{ link }})

--- a/src/main/resources/scm/template/textile/changeset_reference.mustache
+++ b/src/main/resources/scm/template/textile/changeset_reference.mustache
@@ -3,8 +3,11 @@
 {{ content.description }}
 
 **Author:** {{ author }}
+{{#contributors.Committed-by}}
+**Committed by:** {{ . }}
+{{/contributors.Committed-by}}
 {{#principal}}
-**Committer:** {{ principal }}
+**Pushed by:** {{ principal }}
 {{/principal}}
 
 "Changes":{{ link }}

--- a/src/main/resources/scm/template/textile/changeset_statechange.mustache
+++ b/src/main/resources/scm/template/textile/changeset_statechange.mustache
@@ -3,8 +3,11 @@
 {{ content.description }}
 
 **Author:** {{ author }}
+{{#contributors.Committed-by}}
+**Committed by:** {{ . }}
+{{/contributors.Committed-by}}
 {{#principal}}
-**Committer:** {{ principal }}
+**Pushed by:** {{ principal }}
 {{/principal}}
 
 "Changes":{{ link }}


### PR DESCRIPTION
## Proposed changes

Fixes the label 'committer'. Beforehand, this was the user pushing the commit. For hg and git this did not has to be the committer. Now this user is labelled as 'pushed by', and the real committer is added as 'committed by' if this user is different from the author.

### Your checklist for this pull request

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

**Contributor**:
- [x] PR is well described and the description can be used as a commit message on squash
- [ ] Related issues linked to PR if existing and labels set
- [ ] New code is covered with unit tests
- [ ] New/updated ui components are tested inside the storybook (module ui-components only) 
- [x] [Changelog entry file](https://github.com/scm-manager/changelog#changelog-entry-files) created in `gradle/changelog`
- [ ] Feature has been tested with different permissions
- [ ] Documentation updated (only necessary for new features or changed behaviour)

**Reviewer**:
- [ ] The clean code principles are respected ([CleanCode](https://clean-code-developer.com/virtues/))
- [ ] All new code/logic is implemented on the right spot / "Should this be done here?"
- [ ] UI changes fits into the layout
- [ ] The UI views / components are responsive (mobile views)
- [ ] Correct translations are available

### Checklist for branch merge request (not required for forks)

- [ ] Branch is green/blue on [Jenkins](https://oss.cloudogu.com/jenkins/)
- [ ] Quality Gate passed on [SonarQube](https://sonarcloud.io/organizations/scm-manager/projects)
